### PR TITLE
🐛 fix evolutions liée à la sélection de la période acheteur.php

### DIFF
--- a/ui/acheteur.php
+++ b/ui/acheteur.php
@@ -28,7 +28,7 @@ if (isset($_GET['date_max']) && is_date($_GET['date_max']) && $secured == true) 
 
 if ($secured == true) {
   $hide_filter = false;
-  if(isset($_GET['hide_filter']) && $_GET['hide_filter'] == true){
+  if(isset($_GET['hide_filter']) && $_GET['hide_filter'] == "true" && $_GET['hide_filter'] == true){
     $hide_filter = true;
   }
   $id = $_GET['i'];

--- a/ui/acheteur.php
+++ b/ui/acheteur.php
@@ -50,8 +50,8 @@ if ($secured == true) {
 
   //mise à jour périodicité si sélection de date min et max, surcharge la périodicité par défaut présente dans config.php
   if(isset($date_min)) {
-  $debut = new DateTime($date_min);
-  $donnees_a_partir_du = $formatter->format($debut);
+    $debut = new DateTime($date_min);
+    $donnees_a_partir_du = $formatter->format($debut);
   }
   if(!isset($date_max)) {
     $fin = new DateTime(date('Y-m-d'));

--- a/ui/acheteur.php
+++ b/ui/acheteur.php
@@ -51,6 +51,7 @@ if ($secured == true) {
   //mise à jour périodicité si sélection de date min et max, surcharge la périodicité par défaut présente dans config.php
   if(isset($date_min)) {
   $debut = new DateTime($date_min);
+  $donnees_a_partir_du = $formatter->format($debut);
   }
   if(!isset($date_max)) {
     $fin = new DateTime(date('Y-m-d'));
@@ -63,7 +64,6 @@ if ($secured == true) {
   $months = $interval->format('%r%m');
   $nb_mois = $yearsInMonths + $months;
 
-  $donnees_a_partir_du = $formatter->format(new DateTime($date_min));
 
   $kpi = getKPI($connect, $id, $nb_mois, 0, $date_min, $date_max);
   $marches = getDatesMontantsLieu($connect, $id, $nb_mois, $date_min, $date_max);

--- a/ui/widget-acheteur-distrib-temporelle.php
+++ b/ui/widget-acheteur-distrib-temporelle.php
@@ -1,5 +1,3 @@
-<title>Localisation et contexte</title>
-
 <?php
 
 $iframe = false;
@@ -7,21 +5,6 @@ if (isset($_GET['widget'])) {
     $iframe = true;
     if (is_numeric($_GET['widget'])) {
         $id_iframe = $_GET['widget'];
-    }
-    ///// Sécurisation
-    $secured = false;
-    if (is_numeric($_GET['i'])) {
-        $secured = true;
-    }
-
-    if (isset($_GET['date_min']) && is_date($_GET['date_min']) && $secured == true) {
-        $date_min = $_GET['date_min'];
-        $secured = true;
-    }
-      
-    if (isset($_GET['date_max']) && is_date($_GET['date_max']) && $secured == true) {
-        $date_min = $_GET['date_min'];
-        $secured = true;
     }
 }
 
@@ -214,11 +197,11 @@ if (isset($sirene['siren'])) {
 
         // taille des cercles
         var size_bubble = 20;
-        if (t.data.length > 20) size_bubble = 14;
-        if (t.data.length > 40) size_bubble = 13;
-        if (t.data.length > 60) size_bubble = 12;
-        if (t.data.length > 80) size_bubble = 11;
-        if (t.data.length > 100) size_bubble = 10;
+        if (t.data.length > 20) {size_bubble = 14;}
+        if (t.data.length > 40) {size_bubble = 13;}
+        if (t.data.length > 60) {size_bubble = 12;}
+        if (t.data.length > 80)  {size_bubble = 11; }
+        if (t.data.length > 100) { size_bubble = 10; }
 
         // opacité des cercles
         var opacity = 0.7;

--- a/ui/widget-acheteur-distribution.php
+++ b/ui/widget-acheteur-distribution.php
@@ -1,34 +1,16 @@
 <?php
 
 $iframe = false;
-if(isset($_GET['widget'])) {
-$iframe = true;
-if (is_numeric($_GET['widget'])) {
-$id_iframe = $_GET['widget'];
-}
-///// Sécurisation
-$secured = false;
-if (is_numeric($_GET['i'])) {
-     $secured = true;
+if (isset($_GET['widget'])) {
+    $iframe = true;
+    if (is_numeric($_GET['widget'])) {
+        $id_iframe = $_GET['widget'];
+    }
 }
 
-if (isset($_GET['date_min']) && is_date($_GET['date_min']) && $secured == true) {
-    $date_min = $_GET['date_min'];
-    $secured = true;
-}
-  
-if (isset($_GET['date_max']) && is_date($_GET['date_max']) && $secured == true) {
-    $date_min = $_GET['date_min'];
-    $secured = true;
-}
+if ($iframe == true) {
 
-
-}
-
-
-if ($iframe == true){
-
-    $title ="Distribution par catégorie principale d'achat";
+    $title = "Distribution par catégorie principale d'achat";
     include('inc/head.php');
     include('inc/config.php');
     include('inc/localization.php');
@@ -36,8 +18,7 @@ if ($iframe == true){
     <!-- entre heads : ajouter extra css , ... -->
     <link rel="stylesheet" href="assets/leaflet/leaflet.css" />
 
- <?php
-//    include('inc/nav.php');
+    <?php
     require_once('data/connect.php');
     require_once('data/model.php');
     require_once('data/validateurs.php');

--- a/ui/widget-acheteur-indicateurs.php
+++ b/ui/widget-acheteur-indicateurs.php
@@ -1,27 +1,12 @@
 <?php
 
+
 $iframe = false;
 if(isset($_GET['widget'])) {
 $iframe = true;
 if (is_numeric($_GET['widget'])) {
 $id_iframe = $_GET['widget'];
 }
-///// Sécurisation
-$secured = false;
-if (is_numeric($_GET['i'])) {
-    $secured = true;
-}
-
-if (isset($_GET['date_min']) && is_date($_GET['date_min']) && $secured == true) {
-    $date_min = $_GET['date_min'];
-    $secured = true;
-}
-  
-if (isset($_GET['date_max']) && is_date($_GET['date_max']) && $secured == true) {
-    $date_min = $_GET['date_min'];
-    $secured = true;
-}
-
 }
 
 

--- a/ui/widget-acheteur-nature.php
+++ b/ui/widget-acheteur-nature.php
@@ -2,23 +2,10 @@
 
 $iframe = false;
 if(isset($_GET['widget'])) {
-$iframe = true;
-if (is_numeric($_GET['widget'])) {
-$id_iframe = $_GET['widget'];
-}
-///// Sécurisation
-$secured = false;
-if (is_numeric($_GET['i'])) { $secured = true;}
-
-if (isset($_GET['date_min']) && is_date($_GET['date_min']) && $secured == true) {
-    $date_min = $_GET['date_min'];
-    $secured = true;
-}
-  
-if (isset($_GET['date_max']) && is_date($_GET['date_max']) && $secured == true) {
-    $date_max = $_GET['date_max'];
-    $secured = true;
-}
+    $iframe = true;
+    if (is_numeric($_GET['widget'])) {
+        $id_iframe = $_GET['widget'];
+    }
 }
 
 if ($iframe == true){

--- a/ui/widget-acheteur-procedure-suivi.php
+++ b/ui/widget-acheteur-procedure-suivi.php
@@ -2,23 +2,11 @@
 
 $iframe = false;
 if(isset($_GET['widget'])) {
-$iframe = true;
-if (is_numeric($_GET['widget'])) {
-$id_iframe = $_GET['widget'];
-}
-///// Sécurisation
-$secured = false;
-if (is_numeric($_GET['i'])) { $secured = true;}
+    $iframe = true;
+    if (is_numeric($_GET['widget'])) {
+        $id_iframe = $_GET['widget'];
+    }
 
-if (isset($_GET['date_min']) && is_date($_GET['date_min']) && $secured == true) {
-    $date_min = $_GET['date_min'];
-    $secured = true;
-}
-  
-if (isset($_GET['date_max']) && is_date($_GET['date_max']) && $secured == true) {
-    $date_max = $_GET['date_max'];
-    $secured = true;
-}
 }
 
 if ($iframe == true){

--- a/ui/widget-acheteur-qui-realise.php
+++ b/ui/widget-acheteur-qui-realise.php
@@ -6,21 +6,7 @@ if (isset($_GET['widget'])) {
     if (is_numeric($_GET['widget'])) {
         $id_iframe = $_GET['widget'];
     }
-    ///// Sécurisation
-    $secured = false;
-    if (is_numeric($_GET['i'])) {
-        $secured = true;
-    }
-
-    if (isset($_GET['date_min']) && is_date($_GET['date_min']) && $secured == true) {
-        $date_min = $_GET['date_min'];
-        $secured = true;
-    }
-
-    if (isset($_GET['date_max']) && is_date($_GET['date_max']) && $secured == true) {
-        $date_max = $_GET['date_max'];
-        $secured = true;
-    }
+    
 }
 
 if ($iframe == true) {

--- a/ui/widget-acheteur-tous-marches.php
+++ b/ui/widget-acheteur-tous-marches.php
@@ -6,21 +6,6 @@ if (isset($_GET['widget'])) {
     if (is_numeric($_GET['widget'])) {
         $id_iframe = $_GET['widget'];
     }
-    ///// Sécurisation
-    $secured = false;
-    if (is_numeric($_GET['i'])) {
-        $secured = true;
-    }
-
-    if (isset($_GET['date_min']) && is_date($_GET['date_min']) && $secured == true) {
-        $date_min = $_GET['date_min'];
-        $secured = true;
-    }
-
-    if (isset($_GET['date_max']) && is_date($_GET['date_max']) && $secured == true) {
-        $date_min = $_GET['date_min'];
-        $secured = true;
-    }
 }
 
 if ($iframe == true) {


### PR DESCRIPTION
1. Correction : Contrat conclus à partir du : 
![image](https://github.com/collec-data/focus-marches/assets/22080627/e1b8e9d5-a959-4d16-9f7b-a6c2ee1e66f5)

La date est celle par défaut lorsqu'on n'a pas sélectionné de période minimale.

2. Correction de l'intégration en widget, enlèvement du doublon de check de sécurité inutile, car déjà géré lors de l'iframe ou au niveau acheteur.

3. Correction hide_filter qui ne se cache bien que lors d'un hide_filter à true